### PR TITLE
Soluciona problema con links SSL de descarga

### DIFF
--- a/install_plesk.ps1
+++ b/install_plesk.ps1
@@ -6,6 +6,7 @@ echo "Descargando instalador de Plesk..."
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
 $Url = "https://installer-win.plesk.com/plesk-installer.exe"
 $Output = "C:\Windows\Temp\plesk-installer.exe"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $WebClient = New-Object System.Net.WebClient
 $WebClient.DownloadFile( $url , $Output)
 


### PR DESCRIPTION
En versiones recientes, al ejecutarse el script instalador mostraba errores en pantalla como este "AL-1477" y no podía seguir:

![image](https://user-images.githubusercontent.com/32086536/78835411-816b4d80-79c6-11ea-9876-bebdc12269c8.png)

Agregando este fix corrige el problema. Saludos!